### PR TITLE
Task/password reset

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import jwt
 from django.conf import settings
@@ -35,7 +35,15 @@ class User(AbstractUser):
 
     @classmethod
     def generate_activation_token(cls, user_id):
-        payload = {"user_id": user_id, "exp": datetime.utcnow() + timedelta(hours=24)}
+        payload = {"user_id": user_id, "exp": datetime.now(timezone.utc) + timedelta(hours=24)}
+        token = jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256").decode(
+            "utf-8"
+        )
+        return token
+    
+    @classmethod
+    def generate_reset_token(cls, user_id):
+        payload = {"user_id": user_id, "exp": datetime.now(timezone.utc) + timedelta(hours=24)}
         token = jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256").decode(
             "utf-8"
         )

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -35,7 +35,6 @@ class RegistrationSerializer(serializers.ModelSerializer):
         user.save()
         return user
 
-
 class UserSerializer(serializers.ModelSerializer):
     story_count = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,7 +8,9 @@ from .views import (
     RegistrationAPIView,
     UsersListAPIView,
     UserRoleListAPIView,
-    AuthorRetrieveView
+    AuthorRetrieveView,
+    ResetPasswordAPIView,
+    ApplyResetPasswordAPIView,
 )
 
 app_name = "accounts"
@@ -20,6 +22,8 @@ urlpatterns = [
     path("/role/", UserRoleListAPIView.as_view(), name="user_role"),
     path("/change-password-admin/<str:email>/", ChangePasswordView.as_view()),
     path("/disable-user-admin/<str:email>/", DisableUserAPIView.as_view()),
+    path("/reset-password/", ResetPasswordAPIView.as_view(), name="reset-password"),
+    path("/apply-reset-password/", ApplyResetPasswordAPIView.as_view(), name="apply-reset-password"),
     path(
         "/info/<int:id>/",
         AuthorRetrieveView.as_view(),

--- a/config/settings.py
+++ b/config/settings.py
@@ -34,7 +34,7 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY","django-insecure-ap+rrgk$#dzic)-har4=
 DEBUG = os.getenv("DJANGO_DEBUG",True)
 
 ALLOWED_HOSTS = ["*"]
-CLIENT_BASE_URL = os.getenv("DJANGO_BASE_URL","127.0.0.1:8000")
+WEBSITE_BASE_URL = os.getenv("WEBSITE_BASE_URL","127.0.0.1:5173")
 
 # Application definition
 


### PR DESCRIPTION
Note that reset and activation links now go to site-frontend.
CLIENT_BASE_URL is no longer used.
WEBSITE_BASE_URL should be the front-end URL.